### PR TITLE
Add csrf_token to local admin login, and my uni to superusers

### DIFF
--- a/meaningfulconsent/settings_shared.py
+++ b/meaningfulconsent/settings_shared.py
@@ -80,6 +80,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = [
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -197,7 +198,7 @@ WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper',
 WIND_STAFF_MAPPER_GROUPS = ['tlc.cunix.local:columbia.edu']
 WIND_SUPERUSER_MAPPER_GROUPS = [
     'anp8', 'jb2410', 'zm4', 'cld2156',
-    'sld2131', 'amm8', 'mar227', 'jed2161', 'lrw2128']
+    'sld2131', 'amm8', 'mar227', 'jed2161', 'lrw2128', 'njn2118']
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_COOKIE_HTTPONLY = True

--- a/meaningfulconsent/templates/admin/login.html
+++ b/meaningfulconsent/templates/admin/login.html
@@ -25,6 +25,7 @@ login through WIND with it</p>
 <p>otherwise: </p>
 
 <form action="{{ app_path }}" method="post" id="login-form">
+    {% csrf_token %}
   <div class="form-row">
     <label for="id_username">{% trans 'Username:' %}</label> <input type="text" name="username" id="id_username" />
   </div>


### PR DESCRIPTION
I was trying to log in to the meaningfulconsent admin on staging,
to compare the UserProfile admin to the Participant admin I'm making
on worth2.

I couldn't login with my uni, so I've added it to superusers.

And there was a csrf error when attempting the local login.
