### PR TITLE
Complete page submit on next

### DIFF
--- a/meaningfulconsent/templates/main/participant_language.html
+++ b/meaningfulconsent/templates/main/participant_language.html
@@ -41,7 +41,7 @@
         <div class="col-sm-10">
             <div class="row">
                 <div class="col-sm-5 col-sm-offset-4">
-                <form action="{% url 'participant-language' %}" method="post">
+                <form name='choose-language' action="{% url 'participant-language' %}" method="post">
                     {% csrf_token %}
                     <h3>Choose Language</h3>
                     <div id="content" class="pageblock choose-language-quiz">
@@ -63,7 +63,7 @@
             </div>
         </div>
         <div class="col-sm-1 next">
-            <a href="#" class="btn dimmed"
+            <a href="#" class="btn btn-choose-language"
                 data-trigger="manual" data-placement="left"
                 data-title="{% trans 'Oops!' %}"
                 data-content="{% trans 'Please answer all questions before you move on.' %}"

--- a/meaningfulconsent/templates/pagetree/page.html
+++ b/meaningfulconsent/templates/pagetree/page.html
@@ -35,6 +35,14 @@
             <li>
                 <a href="{{section.get_edit_url}}">Edit Page</a>
             </li>
+            {% if is_submitted %}
+                <li>
+                    <form action="." method="post">{% csrf_token %}
+                        <input type="hidden" name="action" value="reset" />
+                        <input type="submit" value="Clear Answers" class="btn btn-anchor" />
+                    </form>
+                </li>
+            {% endif %}
         {% endif %}
 
         {% if request.user.profile.is_participant %}    
@@ -83,15 +91,15 @@
             {% endif %}
         </div>
         <div class="col-sm-10">
-            <form action="." method="post">
+            <form name='content-form' action="." method="post">
                 <div class="row">
                     <div class="col-md-12">
                         <div id="content">
                             {% for block in section.pageblock_set.all %}
                                 <div class="pageblock
-                                 {% if block.css_extra %}
-                                    {{block.css_extra}}
-                                 {% endif %}">
+                                    {% if block.css_extra %}
+                                        {{block.css_extra}}
+                                    {% endif %}">
                                     {% if block.label %}
                                         <h3>{{block.label}}</h3>
                                      {% endif %}
@@ -106,10 +114,7 @@
         <div class="col-sm-1 next">
             {% language request.user.profile.language %}
             {% if not next_section or next_section.is_root %}
-                <a href="#" role="button" data-toggle="modal"
-                    data-target="#end-session-modal"
-                    data-backdrop="static"
-                    data-keyboard="false"
+                <a href="#" data-target="#end-session-modal"
             {% else %}
                 <a href="{{next_section.get_absolute_url}}"
             {% endif %}
@@ -117,7 +122,7 @@
                     data-title="{% trans 'Oops!' %}"
                     data-content="{% trans 'Please answer all questions before you move on.' %}"
                     data-spy="affix"
-                    class="btn {% if needs_submit and not is_submitted %}dimmed{% endif %}">
+                    class="btn btn-submit-page">
                 <span class="glyphicon glyphicon-circle-arrow-right"></span>
             </a>
             {% endlanguage %}

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -4,6 +4,7 @@ html {
 
 body {
   background-color: #fff;
+  min-height: 500px;
 }
 
 .pageblock {
@@ -64,6 +65,10 @@ a[disabled] {
         float: left;
     }
 }
+
+.topic-rating-summary .panel-heading {
+    padding: 10px 11px;
+} 
 
 /* Priority colors */
 .pr-very-important {
@@ -813,4 +818,11 @@ and (orientation: portrait) {
     #send-to-printer {
         display: none
     }
+}
+
+.btn-anchor {
+    color: #777;
+    background-color: white;
+    padding-top: 14px;
+    padding-bottom: 5px;
 }


### PR DESCRIPTION
Previously, this interactive's next button was dimmed until all input controls were checked/selected. The next button then lit up. Error messaging was displayed if the disabled next button was clicked.

However, the survey page introduced a free text field, which put the kabosh on this approach.

Modified to
* always enable the next button
* perform the submit (or show incomplete error messaging) when the next button is clicked.