### PR TITLE
remove dependency on django-annoying

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ django-staticmedia==0.2.2
 django-indexer==0.3.0
 django-templatetag-sugar==1.0
 django-paging==0.2.5
-django-annoying==0.8.7
 django-appconf==1.0.1
 django-compressor==2.0
 django-statsd-mozilla==0.3.16


### PR DESCRIPTION
does not appear to be in use