### PR TITLE
remove load from future tag from impersonate template

### DIFF
--- a/meaningfulconsent/templates/impersonate/list_users.html
+++ b/meaningfulconsent/templates/impersonate/list_users.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load url from future %}
 {% block pagetitle %}<h1>Django Impersonate User List</h1>{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
to eliminate compress's complaint `impersonate/list_users.html: 'url' is not a valid tag or filter in tag library 'future'`